### PR TITLE
Feature/issue 18 ingredient selection UI

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,3 +1,7 @@
+.selected {
+  background-color: green;
+  color: white;
+}
 /*
  * This is a manifest file that'll be compiled into application.css.
  *

--- a/app/javascript/controllers/ingredients_controller.js
+++ b/app/javascript/controllers/ingredients_controller.js
@@ -1,19 +1,22 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-toggle(event) {
-  const button = event.currentTarget
+  static MAX_SELECTION = 3
 
-  if (button.classList.contains("selected")) {
-    button.classList.remove("selected")
-    return
+  toggle(event) {
+    const button = event.currentTarget
+
+    if (button.classList.contains("selected")) {
+      button.classList.remove("selected")
+      return
+    }
+
+    if (this.selectedCount() < this.constructor.MAX_SELECTION) {
+      button.classList.add("selected")
+    }
   }
 
-  const selectedCount =
-    this.element.querySelectorAll(".selected").length
-
-  if (selectedCount < 3) {
-    button.classList.add("selected")
+  selectedCount() {
+    return this.element.querySelectorAll(".selected").length
   }
-}
 }

--- a/app/javascript/controllers/ingredients_controller.js
+++ b/app/javascript/controllers/ingredients_controller.js
@@ -1,7 +1,19 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  toggle(event) {
-    event.currentTarget.classList.toggle("selected")
+toggle(event) {
+  const button = event.currentTarget
+
+  if (button.classList.contains("selected")) {
+    button.classList.remove("selected")
+    return
   }
+
+  const selectedCount =
+    this.element.querySelectorAll(".selected").length
+
+  if (selectedCount < 3) {
+    button.classList.add("selected")
+  }
+}
 }

--- a/app/javascript/controllers/ingredients_controller.js
+++ b/app/javascript/controllers/ingredients_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  toggle(event) {
+    event.currentTarget.classList.toggle("selected")
+  }
+}

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -12,4 +12,8 @@
   <button data-action="click->ingredients#toggle">
     ピーマン
   </button>
+
+  <button data-action="click->ingredients#toggle">
+    じゃがいも
+  </button>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,15 @@
-<h1>Home#index</h1>
-<p>Find me in app/views/home/index.html.erb</p>
+<h1>食材を選択</h1>
+
+<div data-controller="ingredients">
+  <button data-action="click->ingredients#toggle">
+    にんじん
+  </button>
+
+  <button data-action="click->ingredients#toggle">
+    玉ねぎ
+  </button>
+
+  <button data-action="click->ingredients#toggle">
+    ピーマン
+  </button>
+</div>


### PR DESCRIPTION
## 概要

食材をタップして選択できるUIを実装しました。
Stimulusを用いて選択状態の管理を行い、最大3件まで選択できる制限を追加しました。

## 実装内容

* 食材ボタンUI作成
* 食材選択時の選択状態（色変更）実装
* 再タップで選択解除できるトグル実装
* 最大3件までの選択制限実装
* 最大選択数を定数化し保守性を向上
* selectedCountメソッド切り出しによるリファクタリング

## 使用技術

* Ruby on Rails
* Stimulus

## 確認項目

* [x] 食材を1〜3件選択できる
* [x] 4件目は選択できない
* [x] 選択済み食材を再タップで解除できる
* [x] 選択状態が視覚的に確認できる

## 実装意図

軽量な状態管理で単純なインタラクションを実装しやすいため、Stimulusを採用しました。
また最大選択数は定数化し、今後の変更容易性を考慮しています。

## 動作確認

* ローカル環境で手動確認済み
* 想定通り最大3件まで選択できることを確認
