### PR TITLE
共通ヘッダーを実装

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,14 +1,3 @@
-<% if user_signed_in? %>
-  <p>ログイン中</p>
-  <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %>
-<% else %>
-  <%= link_to "ログイン", new_user_session_path %>
-  |
-  <%= link_to "新規登録", new_user_registration_path %>
-<% end %>
-
-<hr>
-
 <h1>食材を選んで副菜を提案</h1>
 
 <%= link_to "レシピを提案する", recipes_show_path, class: "btn btn-primary" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,7 @@
   </head>
 
   <body>
+    <%= render "shared/header" %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,15 @@
+<header>
+  <nav>
+    <%= link_to "Side Dish AI", root_path %>
+
+    <% if user_signed_in? %>
+      <%= link_to "レシピ提案", root_path %>
+      <%= link_to "ログアウト", destroy_user_session_path, data: { turbo_method: :delete } %>
+    <% else %>
+      <%= link_to "ログイン", new_user_session_path %>
+      <%= link_to "新規登録", new_user_registration_path %>
+    <% end %>
+  </nav>
+
+  <hr>
+</header>


### PR DESCRIPTION
## 概要

アプリ共通ヘッダーを実装

## 実装内容

* 共通ヘッダーをパーシャル化
* 全ページにヘッダーを表示
* ログイン状態による表示切り替えを実装
* ナビゲーションリンク（ログイン・新規登録・ログアウト・レシピ提案）を追加

## 確認項目

* [x] 全ページにヘッダーが表示される
* [x] 未ログイン時に「ログイン」「新規登録」が表示される
* [x] ログイン時に「レシピ提案」「ログアウト」が表示される
* [x] 各リンクが正常に動作する
