### PR TITLE
レシピと食材の中間テーブル作成

### DIFF
--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,3 +1,6 @@
 class Ingredient < ApplicationRecord
   belongs_to :ingredient_category
+
+  has_many :recipe_ingredients, dependent: :destroy
+  has_many :recipes, through: :recipe_ingredients
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,2 +1,4 @@
 class Recipe < ApplicationRecord
+  has_many :recipe_ingredients, dependent: :destroy
+  has_many :ingredients, through: :recipe_ingredients
 end

--- a/app/models/recipe_ingredient.rb
+++ b/app/models/recipe_ingredient.rb
@@ -1,0 +1,4 @@
+class RecipeIngredient < ApplicationRecord
+  belongs_to :recipe
+  belongs_to :ingredient
+end

--- a/db/migrate/20260624141926_create_recipe_ingredients.rb
+++ b/db/migrate/20260624141926_create_recipe_ingredients.rb
@@ -1,0 +1,10 @@
+class CreateRecipeIngredients < ActiveRecord::Migration[8.1]
+  def change
+    create_table :recipe_ingredients do |t|
+      t.references :recipe, null: false, foreign_key: true
+      t.references :ingredient, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_24_135701) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_24_141926) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -26,6 +26,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_135701) do
     t.string "name"
     t.datetime "updated_at", null: false
     t.index ["ingredient_category_id"], name: "index_ingredients_on_ingredient_category_id"
+  end
+
+  create_table "recipe_ingredients", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "ingredient_id", null: false
+    t.bigint "recipe_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["ingredient_id"], name: "index_recipe_ingredients_on_ingredient_id"
+    t.index ["recipe_id"], name: "index_recipe_ingredients_on_recipe_id"
   end
 
   create_table "recipes", force: :cascade do |t|
@@ -48,4 +57,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_135701) do
   end
 
   add_foreign_key "ingredients", "ingredient_categories"
+  add_foreign_key "recipe_ingredients", "ingredients"
+  add_foreign_key "recipe_ingredients", "recipes"
 end

--- a/test/fixtures/recipe_ingredients.yml
+++ b/test/fixtures/recipe_ingredients.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  recipe: one
+  ingredient: one
+
+two:
+  recipe: two
+  ingredient: two

--- a/test/models/recipe_ingredient_test.rb
+++ b/test/models/recipe_ingredient_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RecipeIngredientTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要

レシピと食材を紐付けるための中間テーブル recipe_ingredients を作成

### 変更内容
RecipeIngredient モデルを作成
recipe_ingredients テーブルを作成
recipe_id 外部キーを追加
ingredient_id 外部キーを追加
Recipeモデルに関連付けを追加
has_many :recipe_ingredients
has_many :ingredients, through: :recipe_ingredients
Ingredientモデルに関連付けを追加
has_many :recipe_ingredients
has_many :recipes, through: :recipe_ingredients
RecipeIngredientモデルに関連付けを追加
belongs_to :recipe
belongs_to :ingredient
### 動作確認
bin/rails db:migrate が成功することを確認
Railsコンソールで Recipe、Ingredient、RecipeIngredient の関連付けが利用できることを確認
recipe.ingredients
ingredient.recipes

が正常に取得できることを確認

### 確認してほしい点
モデル間の関連付け設定に問題がないか
中間テーブルの設計に改善点がないか