### PR TITLE
お気に入り機能用のfavoritesテーブルを作成

### DIFF
--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,4 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :recipe
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,4 +1,7 @@
 class Recipe < ApplicationRecord
   has_many :recipe_ingredients, dependent: :destroy
   has_many :ingredients, through: :recipe_ingredients
+
+  has_many :favorites, dependent: :destroy
+  has_many :users, through: :favorites
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+  devise :database_authenticatable,
+         :registerable,
+         :recoverable,
+         :rememberable,
+         :validatable
+
+  has_many :favorites, dependent: :destroy
+  has_many :favorite_recipes, through: :favorites, source: :recipe
 end

--- a/db/migrate/20260624144404_create_favorites.rb
+++ b/db/migrate/20260624144404_create_favorites.rb
@@ -1,0 +1,10 @@
+class CreateFavorites < ActiveRecord::Migration[8.1]
+  def change
+    create_table :favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :recipe, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_24_141926) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_24_144404) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "favorites", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "recipe_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["recipe_id"], name: "index_favorites_on_recipe_id"
+    t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
 
   create_table "ingredient_categories", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -56,6 +65,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_24_141926) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "favorites", "recipes"
+  add_foreign_key "favorites", "users"
   add_foreign_key "ingredients", "ingredient_categories"
   add_foreign_key "recipe_ingredients", "ingredients"
   add_foreign_key "recipe_ingredients", "recipes"

--- a/test/fixtures/favorites.yml
+++ b/test/fixtures/favorites.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  recipe: one
+
+two:
+  user: two
+  recipe: two

--- a/test/models/favorite_test.rb
+++ b/test/models/favorite_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FavoriteTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要

お気に入り機能実装に向けて、ユーザーとレシピを紐付けるfavoritesテーブルを作成しました。

## 変更内容

* Favoriteモデル作成
* favoritesテーブル作成
* user_id外部キー追加
* recipe_id外部キー追加
* Userモデルに関連付け追加
* Recipeモデルに関連付け追加
* Favoriteモデルに関連付け追加

## 動作確認

* マイグレーション成功
* Favoriteレコード作成成功
* user.favorite_recipesでお気に入りレシピ取得確認
* recipe.usersでお気に入り登録ユーザー取得確認

## 確認してほしい点

* アソシエーション設計に問題がないか
* テーブル設計に改善点がないか
