### PR TITLE
保存レシピ削除機能を追加

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -19,4 +19,11 @@ class FavoritesController < ApplicationController
 
     redirect_to root_path, notice: "レシピを保存しました"
   end
+
+  def destroy
+    favorite = current_user.favorites.find_by!(recipe_id: params[:id])
+    favorite.destroy
+
+    redirect_to favorites_path, notice: "保存したレシピを削除しました"
+  end
 end

--- a/app/views/favorites/show.html.erb
+++ b/app/views/favorites/show.html.erb
@@ -4,4 +4,13 @@
 
 <p><%= simple_format(@recipe.instructions) %></p>
 
+<%= button_to "保存を解除",
+              favorite_path(@recipe),
+              method: :delete,
+              data: {
+                turbo_confirm: "このレシピを削除しますか？"
+              } %>
+
+<br>
+
 <%= link_to "保存レシピ一覧へ戻る", favorites_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,5 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
   resources :ingredients, only: [ :index ]
-  resources :favorites, only: [ :index, :show, :create ]
+  resources :favorites, only: [ :index, :show, :create, :destroy ]
 end


### PR DESCRIPTION
## 概要

保存したレシピを削除できる機能を追加

## 実装内容

* FavoritesControllerにdestroyアクションを追加
* 保存レシピ詳細ページに削除ボタンを追加
* 削除前に確認ダイアログを表示
* 削除後は保存レシピ一覧へリダイレクトするように設定

## 確認内容

* 保存レシピ詳細ページから削除できること
* 削除確認ダイアログが表示されること
* 削除後に保存レシピ一覧へ遷移すること
* 削除したレシピが一覧に表示されなくなること