### PR TITLE
Add recipe generation error page

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -540,3 +540,49 @@ body {
   gap: 20px;
   flex-wrap: wrap;
 }
+
+/* ==========================
+   Recipe Error
+========================== */
+
+.recipe-error {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 80px 20px;
+}
+
+.error-card {
+  background: white;
+  border-radius: 28px;
+  padding: 60px;
+  max-width: 700px;
+  width: 100%;
+  text-align: center;
+  box-shadow: 0 10px 30px rgba(0,0,0,.08);
+}
+
+.error-icon {
+  font-size: 72px;
+  margin-bottom: 24px;
+}
+
+.error-card h1 {
+  color: #6d4c41;
+  font-size: 42px;
+  margin-bottom: 24px;
+}
+
+.error-card p {
+  color: #666;
+  font-size: 22px;
+  line-height: 1.8;
+}
+
+.error-card .recipe-buttons {
+  margin-top: 40px;
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -15,17 +15,23 @@ class RecipesController < ApplicationController
         RecipeGenerator.new.generate(ingredients.map(&:name))
       end
 
+    # =========================
+    # レシピ生成失敗
+    # =========================
+    if recipe_data.nil?
+      render :error, status: :unprocessable_entity
+      return
+    end
+
     recipe = Recipe.create!(
       title: recipe_data[:title].to_s,
       description: recipe_data[:description].to_s
     )
 
-    # =========================
-    # 🔥 ここが重要（中間テーブル）
-    # =========================
+    # 食材との関連付け
     recipe.ingredients << ingredients
 
-    # stepsはカラム保存
+    # 作り方保存
     recipe.update!(
       steps: recipe_data[:steps].to_json
     )

--- a/app/services/recipe_generator.rb
+++ b/app/services/recipe_generator.rb
@@ -21,7 +21,7 @@ class RecipeGenerator
 
     result = JSON.parse(cleaned, symbolize_names: true)
 
-    # 型保証（ここが重要）
+    # 型保証
     result[:title] = result[:title].to_s
     result[:description] = result[:description].to_s
 
@@ -29,15 +29,10 @@ class RecipeGenerator
     result[:steps] = normalize_array(result[:steps])
 
     result
-  rescue => e
-    Rails.logger.error("RecipeGenerator Error: #{e.message}")
 
-    {
-      title: "エラー",
-      description: "レシピ生成に失敗しました",
-      ingredients: [],
-      steps: []
-    }
+  rescue StandardError => e
+    Rails.logger.error("RecipeGenerator Error: #{e.message}")
+    nil
   end
 
   private
@@ -57,7 +52,7 @@ class RecipeGenerator
   end
 
   # =========================
-  # プロンプト（条件フル保持）
+  # プロンプト
   # =========================
   def prompt(ingredients)
     <<~PROMPT

--- a/app/views/recipes/error.html.erb
+++ b/app/views/recipes/error.html.erb
@@ -1,0 +1,34 @@
+<div class="recipe-error">
+
+  <div class="error-card">
+
+    <div class="error-icon">
+      ⚠️
+    </div>
+
+    <h1>レシピを生成できませんでした</h1>
+
+    <p>
+      通信状況やAIサービスの混雑により、
+      レシピを作成できませんでした。
+    </p>
+
+    <p>
+      時間をおいて、もう一度お試しください。
+    </p>
+
+    <div class="recipe-buttons">
+
+      <%= link_to "🔄 もう一度試す",
+          root_path,
+          class: "btn-primary" %>
+
+      <%= link_to "🏠 トップへ戻る",
+          root_path,
+          class: "btn-secondary" %>
+
+    </div>
+
+  </div>
+
+</div>


### PR DESCRIPTION
## 概要

レシピ生成失敗時のエラー画面を実装

## 実装内容

- RecipeGeneratorの例外処理を改善
- RecipesControllerにエラーハンドリング追加
- エラー画面(error.html.erb)を追加
- エラー画面のUIデザイン実装
- 「もう一度試す」「トップへ戻る」ボタン追加

## 動作確認

- [x] レシピ生成成功時は通常どおり表示される
- [x] レシピ生成失敗時にエラー画面が表示される
- [x] 「もう一度試す」でトップへ戻る
- [x] 「トップへ戻る」が動作する